### PR TITLE
Add image preview when selecting a new image

### DIFF
--- a/src/pages/products/ProductDetails.js
+++ b/src/pages/products/ProductDetails.js
@@ -155,7 +155,7 @@ const ProductDetails = (props) => {
                             alt="product"
                           />
                         ) : (
-                          <p>No Photo Selected!</p>
+                          <p className="mx-auto">No Photo Selected!</p>
                         )}
                       </div>
                     </Col>


### PR DESCRIPTION
***
Fixes issue #34. This adds image preview capabilities for the product details. If the user wants to change the photo of an existing product, it will automatically preview it. If in any case that the user wants to cancel its changes, it can also revert back to the original image.


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] code is in uniquely-named feature branch and has no merge conflicts 📁
* [ ] screenshots/GIFs are attached :paperclip: in case of UI changes
