### PR TITLE
fix: product details UI

### DIFF
--- a/src/pages/products/ImageInput/ImageInput.js
+++ b/src/pages/products/ImageInput/ImageInput.js
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import PropTypes from "prop-types";
-import { Row, Col, Input, Button, FormText } from "reactstrap";
+import { Row, Col, Input, Button } from "reactstrap";
 
 const propTypes = {
   setImageFile: PropTypes.func.isRequired,
@@ -42,6 +42,7 @@ function ImageInput({ setImageFile, imageUrl, imageFile }) {
       </Col>
       <Col>
         <Button
+          className="mt-1"
           style={{ borderRadius: 15, padding: 0 }}
           color="warning"
           outline
@@ -65,9 +66,6 @@ function ImageInput({ setImageFile, imageUrl, imageFile }) {
           onChange={(e) => setImageFile(e.target.files[0])}
           accept="image/*"
         />
-        <FormText>
-          Put text here about what type of image should be uploaded
-        </FormText>
       </Col>
     </Row>
   );

--- a/src/pages/products/ProductDetails.js
+++ b/src/pages/products/ProductDetails.js
@@ -169,7 +169,9 @@ const ProductDetails = (props) => {
                           required
                         />
                         {productName === "" ? (
-                          <FormFeedback>Product name required!</FormFeedback>
+                          <FormFeedback>
+                            Please provide a product name
+                          </FormFeedback>
                         ) : null}
                       </FormGroup>
                     </Col>


### PR DESCRIPTION
Fixes Issue #112 
- Overlapping buttons → Upload Photo button and the Image button
- "Put text here..." may not be needed.
- Change "Product name required!" to "Please provide a product name"
![image](https://user-images.githubusercontent.com/60991513/132809917-002b33cc-667d-48c8-91cc-1a4408b29d30.png)


<!-- Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks! -->

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [x] screenshots/GIFs are attached :paperclip: in case of UI changes
