### PR TITLE
Changed the logic for getting order details

### DIFF
--- a/src/components/OrderList/OrderList.js
+++ b/src/components/OrderList/OrderList.js
@@ -37,8 +37,7 @@ function OrderList({ filter }) {
             <th scope="row">
               <Link
                 to={{
-                  pathname: `/admin/orders/${order.simplifiedID}-${index}`,
-                  state: { order },
+                  pathname: `/admin/orders/${order.simplifiedID}`,
                 }}
               >
                 <span className="mb-0 text-sm">{order.simplifiedID}</span>

--- a/src/components/OrderList/OrderList.js
+++ b/src/components/OrderList/OrderList.js
@@ -4,15 +4,15 @@
 
 import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { Table, Badge } from "reactstrap";
 
 import LoginContext from "../../contexts/LoginContext";
 
 function OrderList({ filter }) {
   const headers = ["Order ID", "Date", "Name", "Items", "Status", "Amount"];
+  const history = useHistory();
   const { userOrders } = useContext(LoginContext);
-  console.log(userOrders);
 
   const badgeColor = {
     UNPAID: "warning",
@@ -33,7 +33,10 @@ function OrderList({ filter }) {
       if (filter === "all" || filter === orderStatus.toLowerCase()) {
         isEmpty = false;
         return (
-          <tr>
+          <tr
+            style={{ cursor: "pointer" }}
+            onClick={() => history.push(`/admin/orders/${order.simplifiedID}`)}
+          >
             <th scope="row">
               <Link
                 to={{
@@ -85,7 +88,7 @@ function OrderList({ filter }) {
   };
 
   return (
-    <Table className="align-items-center table-flush" responsive>
+    <Table className="align-items-center table-flush table-hover" responsive>
       <thead className="thead-light">
         <tr>
           {headers.map((header) => (

--- a/src/components/OrderList/OrderList.js
+++ b/src/components/OrderList/OrderList.js
@@ -38,11 +38,7 @@ function OrderList({ filter }) {
             onClick={() => history.push(`/admin/orders/${order.simplifiedID}`)}
           >
             <th scope="row">
-              <Link
-                to={{
-                  pathname: `/admin/orders/${order.simplifiedID}`,
-                }}
-              >
+              <Link to={`/admin/orders/${order.simplifiedID}`}>
                 <span className="mb-0 text-sm">{order.simplifiedID}</span>
               </Link>
             </th>

--- a/src/components/OrderList/OrderList.js
+++ b/src/components/OrderList/OrderList.js
@@ -28,7 +28,7 @@ function OrderList({ filter }) {
 
   const displayOrders = () => {
     let isEmpty = true;
-    const orderView = userOrders?.map((order, index) => {
+    const orderView = userOrders?.map((order) => {
       const { orderStatus } = order;
       if (filter === "all" || filter === orderStatus.toLowerCase()) {
         isEmpty = false;

--- a/src/pages/orders/OrderDetails.js
+++ b/src/pages/orders/OrderDetails.js
@@ -16,9 +16,13 @@ const OrderDetails = () => {
   /* eslint-disable react/destructuring-assignment */
   const { orderID } = useParams();
   const { userOrders } = useContext(LoginContext);
-  const orderIndex = orderID.split("-")[1];
-  const order = userOrders[orderIndex];
-  console.log(order);
+  let order;
+  for (let i = 0; i < userOrders.length; i++) {
+    if (userOrders[i].simplifiedID === orderID) {
+      order = userOrders[i];
+      break;
+    }
+  }
   if (order)
     return (
       <Container fluid className="mt-5 w-lg-75 w-100">

--- a/src/pages/orders/OrderDetails.js
+++ b/src/pages/orders/OrderDetails.js
@@ -16,13 +16,10 @@ const OrderDetails = () => {
   /* eslint-disable react/destructuring-assignment */
   const { orderID } = useParams();
   const { userOrders } = useContext(LoginContext);
-  let order;
-  for (let i = 0; i < userOrders.length; i++) {
-    if (userOrders[i].simplifiedID === orderID) {
-      order = userOrders[i];
-      break;
-    }
-  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+  const order = userOrders.find((object) => object.simplifiedID === orderID);
+
   if (order)
     return (
       <Container fluid className="mt-5 w-lg-75 w-100">


### PR DESCRIPTION
This PR intends to change the logic for getting the order details from the cached data. This will remove the problem of getting the wrong data based on its given index in the URL. I've also added a small feature requested by Renz, in which the user is able to click the row to open the order details.

Fixes #154 

<!-- Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks! -->

* [ ] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] screenshots/GIFs are attached :paperclip: in case of UI changes
